### PR TITLE
Npm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin-release/
 html-template/
 libs/RenderIn3D.swf
 bin/*
+node_modules

--- a/build.js
+++ b/build.js
@@ -1,0 +1,81 @@
+var childProcess = require('child_process');
+var path = require('path');
+var flexSdk = require('flex-sdk');
+var binPath = flexSdk.bin.mxmlc;
+
+// Source locations for Scratch and the 3D rendering library
+var proj_dir = path.normalize(__dirname)
+var src_dir = path.join(proj_dir, 'src');
+var src_dir_3d = path.join(proj_dir, '3d_render_src');
+
+// Where to find libraries to link into Scratch
+var libs_dir = path.join(proj_dir, 'libs');
+
+// Where to put the built SWF
+var deploy_dir = path.join(proj_dir, 'bin');
+
+function errorCheckThen(nextCall) {
+    return function(err, stdout, stderr) {
+        if (err) {
+            console.log(err);
+            process.exit(1);
+        } else {
+            nextCall();
+        }
+    };
+}
+
+function compile(src, dest, callback, lib_paths, extra_args) {
+    var args = [
+        '-output', dest,
+        '-debug=false'
+    ];
+
+    if(lib_paths) {
+        lib_paths.forEach(function(lib_path){
+            args.push('-library-path+='+lib_path);
+        });
+    }
+
+    args.push(src);
+
+    if(extra_args) {
+        args = args.concat(extra_args);
+    }
+
+    childProcess.execFile(binPath, args, callback);
+}
+
+var src = path.join(src_dir, 'Scratch.as');
+var libs = [
+    path.join(libs_dir, 'blooddy_crypto.swc'),
+    flexSdk.FLEX_HOME+'/frameworks/libs/framework.swc'
+];
+
+function compileWith3D(callback) {
+    compile(src, path.join(deploy_dir, 'Scratch.swf'), callback, libs, [
+        '-target-player=11.4',
+        '-swf-version=17',
+        '-define=SCRATCH::allow3d,true',
+        '-static-link-runtime-shared-libraries=true'
+    ]);
+}
+
+function compileWithout3D(callback) {
+    compile(src, path.join(deploy_dir, 'ScratchFor10.2.swf'), callback, libs, [
+        '-target-player=10.2',
+        '-swf-version=11',
+        '-define=SCRATCH::allow3d,false',
+        '-static-link-runtime-shared-libraries=true'
+    ]);
+}
+
+compileWith3D(
+    errorCheckThen(function() {
+        compileWithout3D(
+            errorCheckThen(function() {
+                process.exit(0);
+            })
+        )
+    })
+);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "git://github.com/LLK/scratch-flash.git"
   },
   "scripts": {
-    "test": "node tests/build.js"
+    "test": "node tests/build.js",
+    "build": "node build.js"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
This seriously reduces the cruft you need to install to actually build Scratch. It mostly adds a duplicate of tests/build.js with settings modified to be equal to those in the build.xml file. It can be run with `npm run build` which removes the need for `ant` on the developer's system, and removes the need to create a `local.properties` file specifying your flex SDK location (since we simply use the one installed via NPM).
